### PR TITLE
test code enhancement

### DIFF
--- a/app/src/androidTest/java/org/elastos/carrier/FriendAddTest.java
+++ b/app/src/androidTest/java/org/elastos/carrier/FriendAddTest.java
@@ -34,7 +34,7 @@ public class FriendAddTest {
 	private static Carrier carrier;
 
 	@Rule
-	public Timeout globalTimeout = Timeout.seconds(300);
+	public Timeout globalTimeout = Timeout.seconds(600);
 
 	static class TestHandler extends AbstractCarrierHandler {
 		private TestContext mContext;

--- a/app/src/androidTest/java/org/elastos/carrier/FriendInviteTest.java
+++ b/app/src/androidTest/java/org/elastos/carrier/FriendInviteTest.java
@@ -34,7 +34,7 @@ public class FriendInviteTest {
 	private static Carrier carrier;
 
 	@Rule
-	public Timeout globalTimeout = Timeout.seconds(300);
+	public Timeout globalTimeout = Timeout.seconds(600);
 
 	static class TestHandler extends AbstractCarrierHandler {
 		private TestContext mContext;

--- a/app/src/androidTest/java/org/elastos/carrier/FriendMessageTest.java
+++ b/app/src/androidTest/java/org/elastos/carrier/FriendMessageTest.java
@@ -33,7 +33,7 @@ public class FriendMessageTest {
 	private static Carrier carrier;
 
 	@Rule
-	public Timeout globalTimeout = Timeout.seconds(300);
+	public Timeout globalTimeout = Timeout.seconds(600);
 
 	static class TestHandler extends AbstractCarrierHandler {
 		private TestContext mContext;

--- a/app/src/androidTest/java/org/elastos/carrier/GroupGetPeerTest.java
+++ b/app/src/androidTest/java/org/elastos/carrier/GroupGetPeerTest.java
@@ -34,7 +34,7 @@ public class GroupGetPeerTest {
 	private static Carrier carrier;
 
 	@Rule
-	public Timeout globalTimeout = Timeout.seconds(300);
+	public Timeout globalTimeout = Timeout.seconds(600);
 
 	static class TestHandler extends AbstractCarrierHandler {
 		private TestContext mContext;

--- a/app/src/androidTest/java/org/elastos/carrier/GroupInviteJoinTest.java
+++ b/app/src/androidTest/java/org/elastos/carrier/GroupInviteJoinTest.java
@@ -33,7 +33,7 @@ public class GroupInviteJoinTest {
 	private static Carrier carrier;
 
 	@Rule
-	public Timeout globalTimeout = Timeout.seconds(300);
+	public Timeout globalTimeout = Timeout.seconds(600);
 
 	static class TestHandler extends AbstractCarrierHandler {
 		private TestContext mContext;

--- a/app/src/androidTest/java/org/elastos/carrier/GroupMessageTest.java
+++ b/app/src/androidTest/java/org/elastos/carrier/GroupMessageTest.java
@@ -35,7 +35,7 @@ public class GroupMessageTest {
 	private static Carrier carrier;
 
 	@Rule
-	public Timeout globalTimeout = Timeout.seconds(300);
+	public Timeout globalTimeout = Timeout.seconds(600);
 
 	static class TestHandler extends AbstractCarrierHandler {
 		private TestContext mContext;

--- a/app/src/androidTest/java/org/elastos/carrier/GroupTitleTest.java
+++ b/app/src/androidTest/java/org/elastos/carrier/GroupTitleTest.java
@@ -31,7 +31,7 @@ public class GroupTitleTest {
 	private static Carrier carrier;
 
 	@Rule
-	public Timeout globalTimeout = Timeout.seconds(300);
+	public Timeout globalTimeout = Timeout.seconds(600);
 
 	static class TestHandler extends AbstractCarrierHandler {
 		private TestContext mContext;

--- a/app/src/androidTest/java/org/elastos/carrier/common/RobotConnector.java
+++ b/app/src/androidTest/java/org/elastos/carrier/common/RobotConnector.java
@@ -16,7 +16,7 @@ public class RobotConnector extends Socket {
 	private BufferedReader mBufferedReader = null;
 	private String mRobotId = null;
 	private String mRobotAddress = null;
-	private  int SOCKET_TIMEOUT = 120000;
+	private  int SOCKET_TIMEOUT = 600000;
 
 	public static RobotConnector getInstance() {
 		if (robotConnector == null)

--- a/app/src/androidTest/java/org/elastos/carrier/session/ChannelTest.java
+++ b/app/src/androidTest/java/org/elastos/carrier/session/ChannelTest.java
@@ -46,7 +46,7 @@ public class ChannelTest {
 				= new TestSessionRequestCompleteHandler();
 
     @Rule
-    public Timeout globalTimeout = Timeout.seconds(300);
+    public Timeout globalTimeout = Timeout.seconds(600);
 
 	static class TestHandler extends AbstractCarrierHandler {
 		private TestContext mContext;

--- a/app/src/androidTest/java/org/elastos/carrier/session/PortforwardingTest.java
+++ b/app/src/androidTest/java/org/elastos/carrier/session/PortforwardingTest.java
@@ -28,6 +28,7 @@ import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.Inet4Address;
 import java.net.NetworkInterface;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -61,7 +62,7 @@ public class PortforwardingTest {
 	private static final String localIP = getLocalIpAddress();
 
 	@Rule
-	public Timeout globalTimeout = Timeout.seconds(300);
+	public Timeout globalTimeout = Timeout.seconds(600);
 
 	static class TestHandler extends AbstractCarrierHandler {
 		private TestContext mContext;
@@ -591,7 +592,8 @@ public class PortforwardingTest {
 				for (Enumeration<InetAddress> enumIpAddr = intf
 						.getInetAddresses(); enumIpAddr.hasMoreElements();) {
 					InetAddress inetAddress = enumIpAddr.nextElement();
-					if (!inetAddress.isLoopbackAddress() && !inetAddress.isLinkLocalAddress()) {
+					if (!inetAddress.isLoopbackAddress() && !inetAddress.isLinkLocalAddress() &&
+						inetAddress instanceof Inet4Address) {
 						return inetAddress.getHostAddress();
 					}
 				}

--- a/app/src/androidTest/java/org/elastos/carrier/session/RequestReplyTest.java
+++ b/app/src/androidTest/java/org/elastos/carrier/session/RequestReplyTest.java
@@ -43,7 +43,7 @@ public class RequestReplyTest {
 	private static Stream stream;
 
 	@Rule
-	public Timeout globalTimeout = Timeout.seconds(300);
+	public Timeout globalTimeout = Timeout.seconds(600);
 
 	static class TestHandler extends AbstractCarrierHandler {
 		private TestContext mContext;

--- a/app/src/androidTest/java/org/elastos/carrier/session/StreamTest.java
+++ b/app/src/androidTest/java/org/elastos/carrier/session/StreamTest.java
@@ -44,7 +44,7 @@ public class StreamTest {
 	private static Stream stream;
 
 	@Rule
-	public Timeout globalTimeout = Timeout.seconds(300);
+	public Timeout globalTimeout = Timeout.seconds(600);
 
 	static class TestHandler extends AbstractCarrierHandler {
 		private TestContext mContext;


### PR DESCRIPTION
* extend test timeout from 300s to 600s
* extend read robot timeout from 2min to 10min
* exclude ipv6 interfaces from being used in port forwarding tests